### PR TITLE
Update Monitor unit tests for the new protocols

### DIFF
--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -44,6 +44,7 @@ libcybermon_la_SOURCES = address.C base_context.C ber.C			\
 	smtp.C smtp_auth.C socket.C tcp.C tcp_ports.C udp.C udp_ports.C unrecognised.C		\
 	cybermon_qargs.h cybermon_qwriter.h cybermon_qreader.h \
 	hardware_addr_utils.C gre.C esp.C 802_11.C \
+	hardware_addr_utils.h \
 	../include/cybermon/address.h ../include/cybermon/ber.h		\
 	address_map.h		                \
 	../include/cybermon/base_context.h				\
@@ -81,6 +82,8 @@ libcybermon_la_SOURCES = address.C base_context.C ber.C			\
 	../include/cybermon/specification.h ../include/cybermon/tcp.h	\
 	../include/cybermon/thread.h ../include/cybermon/transport.h	\
 	../include/cybermon/udp.h ../include/cybermon/unrecognised.h	\
+	../include/cybermon/gre.h ../include/cybermon/esp.h \
+	../include/cybermon/802_11.h \
 	../include/cybermon/xml.h
 
 ACLOCAL_AMFLAGS = -I m4

--- a/tests/samples/cpsfnet.pcap.monitor
+++ b/tests/samples/cpsfnet.pcap.monitor
@@ -1,108 +1,112 @@
 PCAP: 192.168.122.11:40499 -> 216.34.181.96:80. HTTP GET request
     URL http://cyberprobe.sourceforge.net/
     Host: cyberprobe.sourceforge.net
-    Accept-Language: en-US,en;q=0.5
-    Accept-Encoding: gzip, deflate
-    User-Agent: Mozilla/5.0 (X11; Linux x86_64; rv:25.0) Gecko/20100101 Firefox/25.0
-    Connection: keep-alive
     Accept: text/html,application/xhtml+xml,application/xml;q=0.9,*/*;q=0.8
+    Accept-Language: en-US,en;q=0.5
+    User-Agent: Mozilla/5.0 (X11; Linux x86_64; rv:25.0) Gecko/20100101 Firefox/25.0
+    Accept-Encoding: gzip, deflate
+    Connection: keep-alive
 
 PCAP: 216.34.181.96:80 -> 192.168.122.11:40499. HTTP response 200 OK
     URL http://cyberprobe.sourceforge.net/
-    Content-Type: text/html
-    Age: 0
-    Cache-Control: max-age=172800
-    X-Varnish: 1515310257
-    Via: 1.1 varnish
-    Connection: keep-alive
-    Content-Encoding: gzip
-    Vary: Host, Accept-Encoding, User-Agent
-    Server: Apache/2.2.15 (CentOS)
-    Accept-Ranges: bytes
+    Date: Fri, 10 Oct 2014 20:50:19 GMT
     Last-Modified: Sat, 27 Sep 2014 14:59:40 GMT
     Expires: Sun, 12 Oct 2014 20:50:19 GMT
-    ETag: "2194-5040d4870fc4d"
-    Date: Fri, 10 Oct 2014 20:50:19 GMT
+    X-Varnish: 1515310257
+    Content-Encoding: gzip
     Content-Length: 4289
+    Accept-Ranges: bytes
+    Vary: Host, Accept-Encoding, User-Agent
+    Server: Apache/2.2.15 (CentOS)
+    ETag: "2194-5040d4870fc4d"
+    Connection: keep-alive
+    Content-Type: text/html
+    Cache-Control: max-age=172800
+    Via: 1.1 varnish
+    Age: 0
 
 PCAP: 192.168.122.11:40499 -> 216.34.181.96:80. HTTP GET request
     URL http://cyberprobe.sourceforge.net/kibana-small.png
-    Host: cyberprobe.sourceforge.net
     User-Agent: Mozilla/5.0 (X11; Linux x86_64; rv:25.0) Gecko/20100101 Firefox/25.0
-    Accept-Language: en-US,en;q=0.5
-    Accept-Encoding: gzip, deflate
-    Referer: http://cyberprobe.sourceforge.net/
-    Connection: keep-alive
+    Host: cyberprobe.sourceforge.net
     Accept: image/png,image/*;q=0.8,*/*;q=0.5
+    Accept-Language: en-US,en;q=0.5
+    Referer: http://cyberprobe.sourceforge.net/
+    Accept-Encoding: gzip, deflate
+    Connection: keep-alive
 
 PCAP: 192.168.122.11:40500 -> 216.34.181.96:80. HTTP GET request
     URL http://cyberprobe.sourceforge.net/cyberprobe.png
-    Host: cyberprobe.sourceforge.net
     User-Agent: Mozilla/5.0 (X11; Linux x86_64; rv:25.0) Gecko/20100101 Firefox/25.0
-    Accept-Language: en-US,en;q=0.5
-    Accept-Encoding: gzip, deflate
-    Referer: http://cyberprobe.sourceforge.net/
-    Connection: keep-alive
+    Host: cyberprobe.sourceforge.net
     Accept: image/png,image/*;q=0.8,*/*;q=0.5
+    Accept-Language: en-US,en;q=0.5
+    Referer: http://cyberprobe.sourceforge.net/
+    Accept-Encoding: gzip, deflate
+    Connection: keep-alive
 
 PCAP: 192.168.122.11:40501 -> 216.34.181.96:80. HTTP GET request
     URL http://cyberprobe.sourceforge.net/cyberprobe.css
-    Host: cyberprobe.sourceforge.net
     User-Agent: Mozilla/5.0 (X11; Linux x86_64; rv:25.0) Gecko/20100101 Firefox/25.0
-    Accept-Language: en-US,en;q=0.5
-    Accept-Encoding: gzip, deflate
-    Referer: http://cyberprobe.sourceforge.net/
-    Connection: keep-alive
+    Host: cyberprobe.sourceforge.net
     Accept: text/css,*/*;q=0.1
+    Accept-Language: en-US,en;q=0.5
+    Referer: http://cyberprobe.sourceforge.net/
+    Accept-Encoding: gzip, deflate
+    Connection: keep-alive
 
 PCAP: 216.34.181.96:80 -> 192.168.122.11:40500. HTTP response 200 OK
     URL http://cyberprobe.sourceforge.net/cyberprobe.png
-    Content-Type: image/png
-    Age: 0
-    Cache-Control: max-age=259200
-    X-Varnish: 11327757
-    Connection: keep-alive
-    Via: 1.1 varnish
-    Vary: Host
-    Server: Apache/2.2.15 (CentOS)
-    Accept-Ranges: bytes
+    Date: Fri, 10 Oct 2014 20:50:19 GMT
     Last-Modified: Sat, 27 Sep 2014 14:59:34 GMT
     Expires: Mon, 13 Oct 2014 20:50:19 GMT
-    ETag: "55fe-5040d481cff81"
-    Date: Fri, 10 Oct 2014 20:50:19 GMT
+    X-Varnish: 11327757
     Content-Length: 22014
+    Accept-Ranges: bytes
+    Content-Type: image/png
+    Vary: Host
+    Server: Apache/2.2.15 (CentOS)
+    Connection: keep-alive
+    ETag: "55fe-5040d481cff81"
+    Cache-Control: max-age=259200
+    Via: 1.1 varnish
+    Age: 0
 
 PCAP: 216.34.181.96:80 -> 192.168.122.11:40501. HTTP response 200 OK
     URL http://cyberprobe.sourceforge.net/cyberprobe.css
-    Content-Type: text/css
-    Age: 0
-    Cache-Control: max-age=86400
-    X-Varnish: 1447365568
-    Connection: keep-alive
-    Via: 1.1 varnish
-    Vary: Host
-    Server: Apache/2.2.15 (CentOS)
-    Accept-Ranges: bytes
+    Date: Fri, 10 Oct 2014 20:50:19 GMT
     Last-Modified: Sat, 27 Sep 2014 14:59:44 GMT
     Expires: Sat, 11 Oct 2014 20:50:19 GMT
-    ETag: "358-5040d48b51e5a"
-    Date: Fri, 10 Oct 2014 20:50:19 GMT
+    X-Varnish: 1447365568
     Content-Length: 856
+    Accept-Ranges: bytes
+    Content-Type: text/css
+    Vary: Host
+    Server: Apache/2.2.15 (CentOS)
+    Connection: keep-alive
+    ETag: "358-5040d48b51e5a"
+    Cache-Control: max-age=86400
+    Via: 1.1 varnish
+    Age: 0
 
 PCAP: 216.34.181.96:80 -> 192.168.122.11:40499. HTTP response 200 OK
     URL http://cyberprobe.sourceforge.net/kibana-small.png
-    Content-Type: image/png
-    Age: 0
-    Cache-Control: max-age=259200
-    X-Varnish: 1515310267
-    Connection: keep-alive
-    Via: 1.1 varnish
-    Vary: Host
-    Server: Apache/2.2.15 (CentOS)
-    Accept-Ranges: bytes
+    Date: Fri, 10 Oct 2014 20:50:19 GMT
     Last-Modified: Sat, 27 Sep 2014 14:59:35 GMT
     Expires: Mon, 13 Oct 2014 20:50:19 GMT
-    ETag: "114bd-5040d4824d764"
-    Date: Fri, 10 Oct 2014 20:50:19 GMT
+    X-Varnish: 1515310267
     Content-Length: 70845
+    Accept-Ranges: bytes
+    Content-Type: image/png
+    Vary: Host
+    Server: Apache/2.2.15 (CentOS)
+    Connection: keep-alive
+    ETag: "114bd-5040d4824d764"
+    Cache-Control: max-age=259200
+    Via: 1.1 varnish
+    Age: 0
+
+PCAP: fe80::5054:ff:fead:3ffd -> ff02::2. Unrecognised IP
+  Next Proto   -> 58
+  Payload Size -> 8
 

--- a/tests/samples/ether.pcap.monitor
+++ b/tests/samples/ether.pcap.monitor
@@ -1,0 +1,4 @@
+PCAP: fe80::5054:ff:fead:3ffd -> ff02::2. Unrecognised IP
+  Next Proto   -> 58
+  Payload Size -> 8
+

--- a/tests/samples/exampleorg.pcap.monitor
+++ b/tests/samples/exampleorg.pcap.monitor
@@ -1,3 +1,7 @@
+PCAP: fe80::5054:ff:fead:3ffd -> ff02::2. Unrecognised IP
+  Next Proto   -> 58
+  Payload Size -> 8
+
 PCAP: 192.168.122.11:40973 -> 192.168.122.1:53. DNS query
     Query: name=example.org, type=1, class=1
 
@@ -8,23 +12,23 @@ PCAP: 192.168.122.1:53 -> 192.168.122.11:40973. DNS response
 PCAP: 192.168.122.11:35041 -> 93.184.216.119:80. HTTP GET request
     URL http://example.org/
     Host: example.org
-    Accept-Language: en-US,en;q=0.5
     Accept: text/html,application/xhtml+xml,application/xml;q=0.9,*/*;q=0.8
-    Connection: keep-alive
+    Accept-Language: en-US,en;q=0.5
     User-Agent: Mozilla/5.0 (X11; Linux x86_64; rv:25.0) Gecko/20100101 Firefox/25.0
     Accept-Encoding: gzip, deflate
+    Connection: keep-alive
 
 PCAP: 93.184.216.119:80 -> 192.168.122.11:35041. HTTP response 200 OK
     URL http://example.org/
-    Expires: Fri, 17 Oct 2014 20:49:42 GMT
-    Cache-Control: max-age=604800
-    Content-Length: 1270
-    X-Cache: HIT
+    Server: ECS (ewr/1584)
     Date: Fri, 10 Oct 2014 20:49:42 GMT
     Etag: "359670651"
-    Accept-Ranges: bytes
+    Content-Length: 1270
+    Cache-Control: max-age=604800
+    X-Cache: HIT
     Last-Modified: Fri, 09 Aug 2013 23:54:35 GMT
-    Server: ECS (ewr/1584)
-    x-ec-custom-error: 1
+    Expires: Fri, 17 Oct 2014 20:49:42 GMT
+    Accept-Ranges: bytes
     Content-Type: text/html
+    x-ec-custom-error: 1
 

--- a/tests/samples/ftp.pcap.monitor
+++ b/tests/samples/ftp.pcap.monitor
@@ -1,3 +1,7 @@
+PCAP: fe80::5054:ff:fead:3ffd -> ff02::2. Unrecognised IP
+  Next Proto   -> 58
+  Payload Size -> 8
+
 PCAP: 192.168.122.11:50766 -> 192.168.122.1:53. DNS query
     Query: name=ftp.swfwmd.state.fl.us, type=1, class=1
 
@@ -171,6 +175,10 @@ PCAP: 78.47.249.19:123 -> 192.168.122.11:123. NTP Timestamp
     Transmit Timestamp  -> 1412974420.081311703
     Extension           -> false
 
+PCAP: fe80::5054:ff:fead:3ffd -> ff02::2. Unrecognised IP
+  Next Proto   -> 58
+  Payload Size -> 8
+
 PCAP: 192.168.122.11:123 -> 217.73.16.2:123. NTP Timestamp
     Leap Indicator      -> 0
     Version             -> 3
@@ -225,6 +233,10 @@ PCAP: 204.76.241.31:12970 -> 192.168.122.11:38609. Stream data (size is 1361)
 PCAP: 204.76.241.31:21 -> 192.168.122.11:42945. FTP response 226
     Directory send OK.
 
+PCAP: fe80::5054:ff:fead:3ffd -> ff02::2. Unrecognised IP
+  Next Proto   -> 58
+  Payload Size -> 8
+
 PCAP: 192.168.122.11:42945 -> 204.76.241.31:21. FTP command TYPE I
 
 PCAP: 204.76.241.31:21 -> 192.168.122.11:42945. FTP response 200
@@ -249,4 +261,8 @@ PCAP: 192.168.122.11:42945 -> 204.76.241.31:21. FTP command QUIT
 
 PCAP: 204.76.241.31:21 -> 192.168.122.11:42945. FTP response 221
     Goodbye.
+
+PCAP: fe80::5054:ff:fead:3ffd -> ff02::2. Unrecognised IP
+  Next Proto   -> 58
+  Payload Size -> 8
 

--- a/tests/samples/smtp.pcap.monitor
+++ b/tests/samples/smtp.pcap.monitor
@@ -43,6 +43,10 @@ PCAP: 149.20.54.225:25 -> 192.168.122.11:54320. SMTP response 250
 PCAP: 149.20.54.225:25 -> 192.168.122.11:54320. SMTP response 250
     2.1.5 <bit-bucket@test.smtp.org>... Recipient ok
 
+PCAP: fe80::5054:ff:fead:3ffd -> ff02::2. Unrecognised IP
+  Next Proto   -> 58
+  Payload Size -> 8
+
 PCAP: 192.168.122.11:54320 -> 149.20.54.225:25. SMTP command DATA
 
 PCAP: 149.20.54.225:25 -> 192.168.122.11:54320. SMTP response 354
@@ -86,6 +90,10 @@ PCAP: 176.9.92.196:123 -> 192.168.122.11:123. NTP Timestamp
     Receive Timestamp   -> 1412975520.070941448
     Transmit Timestamp  -> 1412975520.070966244
     Extension           -> false
+
+PCAP: fe80::5054:ff:fead:3ffd -> ff02::2. Unrecognised IP
+  Next Proto   -> 58
+  Payload Size -> 8
 
 PCAP: 192.168.122.11:123 -> 217.73.16.2:123. NTP Timestamp
     Leap Indicator      -> 0

--- a/tests/samples/tcp.pcap.monitor
+++ b/tests/samples/tcp.pcap.monitor
@@ -29,3 +29,7 @@ PCAP: 192.168.122.1:53 -> 192.168.122.11:50485. DNS response
     Query: name=www.google.com, type=28, class=1
     Answer: name=www.google.com, type=28, class=1 -> 2a00:1450:4009:80c::1013
 
+PCAP: fe80::5054:ff:fead:3ffd -> ff02::2. Unrecognised IP
+  Next Proto   -> 58
+  Payload Size -> 8
+


### PR DESCRIPTION
when updating the lua configs, it broke the unit tests. Updated the expected output to include the new types that werent present before 

(also added missing headers to the makefile for the deb build)